### PR TITLE
Ensure MeshCollider.sharedMesh is set when adding ProceduralCylinder to an existing object

### DIFF
--- a/ProceduralCylinder/Assets/Scripts/Procedural/ProceduralCylinder.cs
+++ b/ProceduralCylinder/Assets/Scripts/Procedural/ProceduralCylinder.cs
@@ -250,7 +250,7 @@ public class ProceduralCylinder : MonoBehaviour {
     void SetColliderMesh()
     {
         var meshCollider = gameObject.GetComponent<MeshCollider>();
-        if (meshCollider != null && meshCollider.sharedMesh == null)
+        if (meshCollider != null)
             meshCollider.sharedMesh = modelMesh;
     }
 

--- a/ProceduralCylinder/Assets/Scripts/Procedural/ProceduralCylinder.cs
+++ b/ProceduralCylinder/Assets/Scripts/Procedural/ProceduralCylinder.cs
@@ -8,7 +8,6 @@
 using UnityEngine;
 using System.Collections;
 
-[RequireComponent (typeof (MeshCollider))]
 [RequireComponent (typeof (MeshFilter))]
 [RequireComponent (typeof (MeshRenderer))]
 
@@ -48,6 +47,7 @@ public class ProceduralCylinder : MonoBehaviour {
 		modelMesh.name = "ProceduralCylinderMesh";
 		meshFilter = (MeshFilter)gameObject.GetComponent<MeshFilter>();
 		meshFilter.mesh = modelMesh;
+        SetColliderMesh();
 		
 		//sanity check
 		if(radialSegments < MIN_RADIAL_SEGMENTS)	radialSegments = MIN_RADIAL_SEGMENTS;
@@ -246,6 +246,18 @@ public class ProceduralCylinder : MonoBehaviour {
 	
 	    mesh.tangents = tangents;
 	}
-		
+
+    void SetColliderMesh()
+    {
+        var meshCollider = gameObject.GetComponent<MeshCollider>();
+        if (meshCollider != null && meshCollider.sharedMesh == null)
+            meshCollider.sharedMesh = modelMesh;
+    }
+
+    void Awake()
+    {
+        SetColliderMesh();
+    }
+
 }
 


### PR DESCRIPTION
When adding a ProceduralCyclinder to an existing object I found that the mesh in the MeshCollider was never being set. This patch ensures that if there is a MeshCollider present its sharedMesh is set when the ProceduralCyclinder is changed in the editor or when the Awake method is called on the MonoBehaviour.

Note: The MeshCollider doesn't work with the meshes you generate. Objects fall through the floor